### PR TITLE
fix: ensure USDC is swapped in past swap fails + other fixes

### DIFF
--- a/packages/autotask/src/constants.ts
+++ b/packages/autotask/src/constants.ts
@@ -2,4 +2,6 @@ import { BigNumber } from "ethers";
 
 export const UNISWAP_ROUTER = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D";
 
-export const CLAIMABLE_FEES_THRESHOLD = BigNumber.from(100);
+const USDC_DECIMALS = BigNumber.from(10).pow(6);
+
+export const CLAIMABLE_FEES_THRESHOLD = BigNumber.from(1000).mul(USDC_DECIMALS);

--- a/packages/autotask/src/index.ts
+++ b/packages/autotask/src/index.ts
@@ -10,7 +10,7 @@ import { swapAndSend } from "./swap";
  * NOTE: This must be called with the registered relayer address as Signer
  * @param credentials
  */
-export const handler = async (credentials: RelayerParams) => {
+export const handler = async (credentials: RelayerParams): Promise<void> => {
   const provider = getRelayerProvider(credentials);
   const signer = new DefenderRelaySigner(credentials, provider, {
     speed: "fastest",
@@ -22,11 +22,9 @@ export const handler = async (credentials: RelayerParams) => {
   const routerAddress = getDepositRouterAddress(chainId);
 
   try {
-    const claimedFees = await claim(signer, routerAddress);
+    await claim(signer, routerAddress);
 
-    if (claimedFees != null) {
-      await swapAndSend(signer, routerAddress, claimedFees);
-    }
+    await swapAndSend(signer, routerAddress);
 
     console.log(`Complete!`);
   } catch (e) {


### PR DESCRIPTION
- increase USDC threshold from <$0.01 to $1000 because constantly running the autotask will waste a lot of money on transaction fees
- in case a swap has failed, check the USDC balance of the relayer every time the autotask runs and if greater than the threshold, swap for ETH