### PR TITLE
hardcode relayer to polymarket PLAT-248 PROD-680

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .vscode
+
+packages/test.ts

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymarket/relayer-deposits",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "A template for typescript packages",
   "author": "Sam Hatem <sam.hatem17@gmail.com>",
   "main": "lib/index.js",
@@ -14,6 +14,10 @@
     {
       "name": "Sam Hatem",
       "url": "https://github.com/samhatem"
+    },
+    {
+      "name": "Liam Kovatch",
+      "url": "https://github.com/l-kov"
     }
   ],
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymarket/relayer-deposits",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "A template for typescript packages",
   "author": "Sam Hatem <sam.hatem17@gmail.com>",
   "main": "lib/index.js",

--- a/packages/sdk/src/getRelayers.ts
+++ b/packages/sdk/src/getRelayers.ts
@@ -7,6 +7,7 @@ import { Relayer, RelayerFee } from "./types";
 import { getHttpClient } from "./utils/axios";
 import { RELAY_INFO_TIMEOUT } from "./constants";
 
+/*
 export const getRelayers = async (provider: Provider, chainId: number, maxFees?: RelayerFee): Promise<Relayer[]> => {
     const depositContract = getDepositContract(provider, chainId);
 
@@ -56,4 +57,15 @@ export const getRelayers = async (provider: Provider, chainId: number, maxFees?:
     const filteredRelayers = unFilteredRelayers.filter((relayer: Relayer | null) => !!relayer) as Relayer[];
 
     return filteredRelayers.sort((a: Relayer, b: Relayer) => a.fees.standardFee - b.fees.standardFee) as Relayer[];
+};
+
+*/
+
+export const getRelayers = async (provider: Provider, chainId: number, maxFees?: RelayerFee): Promise<Relayer[]> => {
+    const polymarketRelayer: Relayer = {
+        endpoint: "https://deposit-relayer.polymarket.io",
+        address: "0xdA85b2Cac8Da0D683232837ECdf71315FD6de74E",
+        fees: { standardFee: 0.1, minFee: BigNumber.from("0x2dc6c0") },
+    };
+    return [polymarketRelayer];
 };


### PR DESCRIPTION
avoid webster which doesn't have ssl. Sam deployed contracts so I don't believe we have the owning key to remove webster as a registered relayer directly. Admin address is `0x1C35E441b21E528Dd8385Fd41d1578bE18E247D3`